### PR TITLE
Feature 10 dropdown컴포넌트추가

### DIFF
--- a/knock/src/core/styles/dropdown.module.scss
+++ b/knock/src/core/styles/dropdown.module.scss
@@ -1,0 +1,75 @@
+@import 'global.scss';
+
+@mixin Center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@mixin Button {
+  @include Center;
+  width: 4.9375rem;
+  padding: 0.5rem 0.75rem;
+  gap: 0.25rem;
+  border-radius: 0.5rem;
+  background: $Grayscale-10;
+  cursor: pointer;
+}
+
+.dropdown {
+  &__button {
+    @include Center;
+    @include Button;
+    @include Caption1-Medium;
+    position: relative;
+    color: $Grayscale-40;
+    border: 1px solid $Grayscale-40;
+    &--active {
+      @include Button;
+      @include Caption1-Medium;
+      border: 1px solid $Grayscale-60;
+    }
+  }
+
+  &__content {
+    position: absolute;
+    visibility: visible;
+    top: 120%;
+    right: 0;
+    left: 0;
+
+    &--invisible {
+      position: absolute;
+      visibility: hidden;
+    }
+
+    & ul {
+      @include Shadow(1);
+      @include Center;
+      padding: 0.25rem 0rem;
+      flex-direction: column;
+      border-radius: 0.5rem;
+      border: 1px solid $Grayscale-30;
+      background: $Grayscale-10;
+
+      & li {
+        @include Center;
+        padding: 0.375rem 1rem;
+        gap: 0.5rem;
+        align-self: stretch;
+        background: $Grayscale-10;
+        &:hover {
+          @include Caption1-Medium;
+          background: $Grayscale-20;
+        }
+
+        &:active {
+          color: $Blue-50;
+        }
+      }
+    }
+    &--selected {
+      color: $Blue-50;
+    }
+  }
+}

--- a/knock/src/core/ui/Dropdown/Dropdown.tsx
+++ b/knock/src/core/ui/Dropdown/Dropdown.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import DropdownContent from './DropdownContent';
+
+import '../../styles/dropdown.scss';
+
+interface DropdownProps {
+  children: React.ReactNode;
+  dropdownElementList: React.ReactNode[] | string[];
+  handleSelectElement: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+}
+
+const Dropdown = ({
+  children,
+  dropdownElementList,
+  handleSelectElement,
+}: DropdownProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleOpen = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <div className="dropdown">
+      <button onClick={handleOpen}>{children}</button>
+      <div onClick={handleSelectElement}>
+        <DropdownContent dropdownElementList={dropdownElementList} />
+      </div>
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/knock/src/core/ui/Dropdown/Dropdown.tsx
+++ b/knock/src/core/ui/Dropdown/Dropdown.tsx
@@ -7,23 +7,22 @@ interface DropdownProps {
   children: React.ReactNode;
   dropdownElementList: React.ReactNode[] | string[];
   handleSelectElement: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-  selected: string;
+  selected?: string;
 }
 
 const Dropdown = ({
   children,
   dropdownElementList,
   handleSelectElement,
-  selected,
+  selected = '',
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleOpen = () => {
     setIsOpen((prev) => !prev);
   };
-
   return (
-    <div className="dropdown">
+    <div className={`${styles['dropdown']}`}>
       <button
         className={`${styles['dropdown__button']} ${isOpen ? styles['dropdown__button--active'] : ''}`}
         onClick={handleOpen}

--- a/knock/src/core/ui/Dropdown/Dropdown.tsx
+++ b/knock/src/core/ui/Dropdown/Dropdown.tsx
@@ -1,18 +1,20 @@
 import { useState } from 'react';
 import DropdownContent from './DropdownContent';
 
-import '../../styles/dropdown.scss';
+import styles from '../../styles/dropdown.module.scss';
 
 interface DropdownProps {
   children: React.ReactNode;
   dropdownElementList: React.ReactNode[] | string[];
   handleSelectElement: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  selected: string;
 }
 
 const Dropdown = ({
   children,
   dropdownElementList,
   handleSelectElement,
+  selected,
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -22,10 +24,21 @@ const Dropdown = ({
 
   return (
     <div className="dropdown">
-      <button onClick={handleOpen}>{children}</button>
-      <div onClick={handleSelectElement}>
-        <DropdownContent dropdownElementList={dropdownElementList} />
-      </div>
+      <button
+        className={`${styles['dropdown__button']} ${isOpen ? styles['dropdown__button--active'] : ''}`}
+        onClick={handleOpen}
+      >
+        {children}
+        <div
+          className={`${isOpen ? styles['dropdown__content'] : styles['dropdown__content--invisible']}`}
+          onClick={handleSelectElement}
+        >
+          <DropdownContent
+            dropdownElementList={dropdownElementList}
+            selected={selected}
+          />
+        </div>
+      </button>
     </div>
   );
 };

--- a/knock/src/core/ui/Dropdown/DropdownContent.tsx
+++ b/knock/src/core/ui/Dropdown/DropdownContent.tsx
@@ -1,0 +1,15 @@
+interface DropdownContentProps {
+  dropdownElementList: React.ReactNode[] | string[];
+}
+
+const DropdownContent = ({ dropdownElementList }: DropdownContentProps) => {
+  return (
+    <ul>
+      {dropdownElementList.map((e, idx) => {
+        return <li key={idx}>{e}</li>;
+      })}
+    </ul>
+  );
+};
+
+export default DropdownContent;

--- a/knock/src/core/ui/Dropdown/DropdownContent.tsx
+++ b/knock/src/core/ui/Dropdown/DropdownContent.tsx
@@ -1,12 +1,25 @@
+import styles from '../../styles/dropdown.module.scss';
+
 interface DropdownContentProps {
   dropdownElementList: React.ReactNode[] | string[];
+  selected?: string;
 }
 
-const DropdownContent = ({ dropdownElementList }: DropdownContentProps) => {
+const DropdownContent = ({
+  dropdownElementList,
+  selected = '',
+}: DropdownContentProps) => {
   return (
     <ul>
       {dropdownElementList.map((e, idx) => {
-        return <li key={idx}>{e}</li>;
+        return (
+          <li
+            className={` ${selected === e ? styles['dropdown__content--selected'] : ''}`}
+            key={idx}
+          >
+            {e}
+          </li>
+        );
       })}
     </ul>
   );


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- Dropdown 컴포넌트 추가

# 작업 상세 내용
- Dropdown 컴포넌트 및 DropdownContent 컴포넌트 추가
- Dropdown open/close 기능 구현
- scss를 통한 css 스타일링
- Dropdown 요소가 `string` 타입일 경우, `selected`와 비교하여 선택 요소 처리(blue 색상처리)
- hover / active 에 대한 ui 처리


# 리뷰 요구사항
- 사용하기 편한 방식인가를 확인해주세요
- 구현 방식에 대한 이야기를 해주시면 감사합니다.
- SCSS, BEM에 관련되서 잘못된 점이나 이상한 점이 있으면 말씀해주세요

# 기타

- 사용법
  - props
    - `children`: 드랍다운 버튼에 들어가는 요소(ex-버튼/최신순/이름순/아이콘)
    - `dropdownElementList`: 드랍다운을 클릭했을 때 아래로 내려오는 요소들(`React.ReactNode[] | string[]` 타입)
    - `handleSelectElement` 드랍다운 요소를 클릭했을 때 호출되는 함수
    - `selected?`: 드랍다운을 선택용으로 사용할 때, 드랍다운 요소가 현재 선택된 요소인지 판별하기 위한 변수(ex- `이름순`일 경우, `이름순`이라는 요소가 파란색으로 변경)

  - 아이콘을 같이 넣을 수 있도록 `string`타입과 `React.ReactNode` 타입을 병행하여 확장성을 높였습니다.
  - 예시 이미지
![스크린샷 2024-07-11 오후 11 16 01](https://github.com/Sprint-8-2/KNOCK/assets/113879996/4a0748a5-6df0-43e1-82fb-c41f55cdd325)
