### PR TITLE
Feature 2 공통 Box 버튼 컴포넌트 추가 #2

### DIFF
--- a/knock/src/core/ui/buttons/BoxButton/BoxButton.module.scss
+++ b/knock/src/core/ui/buttons/BoxButton/BoxButton.module.scss
@@ -1,0 +1,70 @@
+@import '../../../styles/global.scss';
+
+@mixin button-theme($theme: 'default') {
+  @if $theme == 'default' {
+    &:hover {
+      border: 2px solid $Brown-50;
+      background: $Brown-40;
+    }
+
+    &:active {
+      background: $Brown-50;
+    }
+
+    &:disabled {
+      border: 1px solid $Brown-30;
+      background: $Brown-30;
+    }
+  } @else if $theme == 'light' {
+    border: 1px solid $Brown-40;
+    background: $Brown-10;
+    color: $Grayscale-40;
+
+    &:hover {
+      border: 2px solid $Brown-40;
+      background: $Brown-10;
+    }
+
+    &:active {
+      background: $Brown-20;
+    }
+
+    &:disabled {
+      border: 1px solid $Brown-30;
+      background: $Brown-10;
+      color: $Brown-30;
+    }
+  }
+}
+
+.button {
+  display: inline-flex;
+  padding: 0.75rem 1.5rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid $Brown-40;
+  border-radius: 0.5rem;
+  background: $Brown-40;
+  color: $Grayscale-10;
+  font-feature-settings:
+    'clig' off,
+    'liga' off;
+  font-family: Pretendard;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.375rem;
+  cursor: pointer;
+  @include button-theme('default');
+
+  &--small {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+
+  &--light {
+    @include button-theme('light');
+  }
+}

--- a/knock/src/core/ui/buttons/BoxButton/BoxButton.module.scss
+++ b/knock/src/core/ui/buttons/BoxButton/BoxButton.module.scss
@@ -18,7 +18,7 @@
   } @else if $theme == 'light' {
     border: 1px solid $Brown-40;
     background: $Brown-10;
-    color: $Grayscale-40;
+    color: $Brown-40;
 
     &:hover {
       border: 2px solid $Brown-40;
@@ -38,6 +38,8 @@
 }
 
 .button {
+  @include Body3-Regular;
+
   display: inline-flex;
   padding: 0.75rem 1.5rem;
   justify-content: center;
@@ -47,18 +49,11 @@
   border-radius: 0.5rem;
   background: $Brown-40;
   color: $Grayscale-10;
-  font-feature-settings:
-    'clig' off,
-    'liga' off;
-  font-family: Pretendard;
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1.375rem;
   cursor: pointer;
   @include button-theme('default');
 
   &--small {
+    @include Caption1-Regular;
     padding: 0.5rem 0.75rem;
     font-size: 0.875rem;
     line-height: 1.125rem;

--- a/knock/src/core/ui/buttons/BoxButton/BoxButton.tsx
+++ b/knock/src/core/ui/buttons/BoxButton/BoxButton.tsx
@@ -1,0 +1,35 @@
+import styles from './BoxButton.module.scss';
+
+interface BoxButtonProps {
+  handleClick: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  isDisalbed?: boolean;
+  children: React.ReactNode;
+  theme?: string;
+  isSmallButton?: boolean;
+}
+
+const BoxButton = ({
+  handleClick,
+  isDisalbed = false,
+  children,
+  theme,
+  isSmallButton,
+}: BoxButtonProps) => {
+  return (
+    <>
+      <button
+        className={`
+					${styles['button']} 
+					${theme === 'light' ? styles['button--light'] : ''}
+					${isSmallButton ? styles['button--small'] : ''}
+				`}
+        onClick={handleClick}
+        disabled={isDisalbed}
+      >
+        {children}
+      </button>
+    </>
+  );
+};
+
+export default BoxButton;

--- a/knock/src/core/ui/buttons/BoxButton/BoxButton.tsx
+++ b/knock/src/core/ui/buttons/BoxButton/BoxButton.tsx
@@ -4,7 +4,7 @@ interface BoxButtonProps {
   handleClick: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   isDisalbed?: boolean;
   children: React.ReactNode;
-  theme?: string;
+  isLightTheme?: boolean;
   isSmallButton?: boolean;
 }
 
@@ -12,16 +12,16 @@ const BoxButton = ({
   handleClick,
   isDisalbed = false,
   children,
-  theme,
-  isSmallButton,
+  isLightTheme = false,
+  isSmallButton = false,
 }: BoxButtonProps) => {
   return (
     <>
       <button
         className={`
 					${styles['button']} 
-					${theme === 'light' ? styles['button--light'] : ''}
 					${isSmallButton ? styles['button--small'] : ''}
+					${isLightTheme ? styles['button--light'] : ''}
 				`}
         onClick={handleClick}
         disabled={isDisalbed}


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요

Box 버튼 컴포넌트 추가

# 작업 상세 내용

<img width="758" alt="image" src="https://github.com/user-attachments/assets/b69189cb-aa81-4b19-bf5c-11498fdad745">

prop 중에
  children: React.ReactNode 는 버튼 내용
  theme?: string 는 버튼 테마로 색상 light 지정 가능. 값 없으면 default
  isSmallButton?: boolean 는 버튼 크기 지정 가능

# 리뷰 요구사항

사용에 불편한 점은 없을지 확인 부탁드립니다

# 기타

Floating, share 버튼도 빠르게 올리겠습니다

Resolves #2 