### PR TITLE
Feature 41 pagination button추가

### DIFF
--- a/knock/src/core/styles/pagination.module.scss
+++ b/knock/src/core/styles/pagination.module.scss
@@ -1,11 +1,11 @@
-@import '../global.scss';
+@import './global.scss';
 
 .pagination {
   display: flex;
   justify-content: center;
   align-items: center;
 
-  & li {
+  &__list {
     text-decoration: none;
   }
 

--- a/knock/src/core/styles/pagination/pagination.module.scss
+++ b/knock/src/core/styles/pagination/pagination.module.scss
@@ -1,0 +1,41 @@
+@import '../global.scss';
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  & li {
+    text-decoration: none;
+  }
+
+  &__button {
+    @include Body1-Regular;
+    border: none;
+    font-family: 'Actor';
+    display: flex;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+    background-color: $Grayscale-10;
+    color: $Grayscale-40;
+    cursor: pointer;
+
+    &:hover {
+      color: $Grayscale-60;
+    }
+
+    &--selected {
+      color: $Brown-40;
+    }
+
+    @media (width < 768px) {
+      @include Body3-Regular;
+      font-family: 'Actor';
+      line-height: 1.5625rem;
+    }
+  }
+}

--- a/knock/src/core/ui/Pagenation/Pagination.tsx
+++ b/knock/src/core/ui/Pagenation/Pagination.tsx
@@ -1,0 +1,27 @@
+import PaginationButton from './PaginationButton';
+
+import styles from '../../styles/pagination/pagination.module.scss';
+
+const Pagination = () => {
+  const arr = [1, 2, 3, 4, 5, 6, 7];
+  const now = 1;
+  return (
+    <ul className={styles['pagination']}>
+      <li>
+        <PaginationButton>{`<`}</PaginationButton>
+      </li>
+      {arr.map((e) => {
+        return (
+          <li key={e}>
+            <PaginationButton isSelected={now === e}>{e}</PaginationButton>
+          </li>
+        );
+      })}
+      <li>
+        <PaginationButton>{`>`}</PaginationButton>
+      </li>
+    </ul>
+  );
+};
+
+export default Pagination;

--- a/knock/src/core/ui/Pagenation/Pagination.tsx
+++ b/knock/src/core/ui/Pagenation/Pagination.tsx
@@ -1,23 +1,52 @@
 import PaginationButton from './PaginationButton';
 
-import styles from '../../styles/pagination/pagination.module.scss';
+import styles from '../../styles/pagination.module.scss';
 
-const Pagination = () => {
-  const arr = [1, 2, 3, 4, 5, 6, 7];
-  const now = 1;
+interface PaginationProps {
+  pageIndexes: number[];
+  currentPage: number;
+  handleNextIndexes: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  handlePrevIndexes: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  handleCurrentPage: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+}
+
+const Pagination = ({
+  pageIndexes,
+  currentPage,
+  handleNextIndexes,
+  handlePrevIndexes,
+  handleCurrentPage,
+}: PaginationProps) => {
+  const handleListClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    const target = e.target as HTMLElement;
+    switch (target.innerText) {
+      case '<':
+        handlePrevIndexes(e);
+        break;
+      case '>':
+        handleNextIndexes(e);
+        break;
+      default:
+        handleCurrentPage(e);
+        break;
+    }
+  };
   return (
-    <ul className={styles['pagination']}>
-      <li>
+    <ul className={styles['pagination']} onClick={handleListClick}>
+      <li className={styles['pagination__list']}>
         <PaginationButton>{`<`}</PaginationButton>
       </li>
-      {arr.map((e) => {
+      {pageIndexes.map((e) => {
         return (
           <li key={e}>
-            <PaginationButton isSelected={now === e}>{e}</PaginationButton>
+            <PaginationButton isSelected={currentPage === e}>
+              {e}
+            </PaginationButton>
           </li>
         );
       })}
-      <li>
+
+      <li className={styles['pagination__list']}>
         <PaginationButton>{`>`}</PaginationButton>
       </li>
     </ul>

--- a/knock/src/core/ui/Pagenation/PaginationButton.tsx
+++ b/knock/src/core/ui/Pagenation/PaginationButton.tsx
@@ -1,4 +1,4 @@
-import styles from '../../styles/pagination/pagination.module.scss';
+import styles from '../../styles/pagination.module.scss';
 
 interface PaginationButtonProps {
   children: React.ReactNode;

--- a/knock/src/core/ui/Pagenation/PaginationButton.tsx
+++ b/knock/src/core/ui/Pagenation/PaginationButton.tsx
@@ -1,0 +1,24 @@
+import styles from '../../styles/pagination/pagination.module.scss';
+
+interface PaginationButtonProps {
+  children: React.ReactNode;
+  isSelected?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+}
+
+const PaginationButton = ({
+  children,
+  onClick = () => {},
+  isSelected = false,
+}: PaginationButtonProps) => {
+  return (
+    <button
+      className={`${styles['pagination__button']} ${isSelected ? styles['pagination__button--selected'] : ''}`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default PaginationButton;


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- pagination button 추가

# 작업 상세 내용
- pagination 버튼 요소 및 버튼 리스트 형식 추가
- props를 통한 내부 로직 전달 및 이벤트 위임을 통한 연결

# 리뷰 요구사항
- 수정할 부분 및 피드백 해주시면 감사합니다 😊

# 기타
- 사용법
  - props
    - `pageIndexes` : 인덱스 리스트(버튼에 들어갈 인덱스들)
    - `currentPage` : 현재 페이지 정보
    - `handleNextIndexes` : 인덱스 리스트 변경 로직(다음 인덱스 리스트로 변경)
    - `handlePrevIndexes` : 인덱스 리스트 변경 로직(이전 인덱스 리스트로 변경)
    - `handleCurrentPage`: 페이지네이션을 위한 버튼 클릭시 페이지 정보 변환 로직
