### PR TITLE
Feature 85 개별피드 페이지 추가 

### DIFF
--- a/knock/src/pages/PostPage.module.scss
+++ b/knock/src/pages/PostPage.module.scss
@@ -1,0 +1,33 @@
+.post-page {
+  &__banner {
+    width: 100%;
+    height: 14.625rem;
+    margin-top: 2rem;
+  }
+
+  &__logo-img {
+    width: 10.6rem;
+    position: absolute;
+    top: 3rem;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &__feed-list {
+    width: 75rem;
+    margin: 10rem auto;
+  }
+
+  &__profile {
+    display: flex;
+    position: absolute;
+    top: 8rem;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  &__floating-btn {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+  }
+}

--- a/knock/src/pages/PostPage.tsx
+++ b/knock/src/pages/PostPage.tsx
@@ -1,5 +1,89 @@
+import Image from '../core/ui/CommonImage/Image';
+import styles from './PostPage.module.scss';
+import postPageBannerImage from '../core/assets/image/feedHeaderImage.png';
+import mainLogo from '../core/assets/image/MainPgaeLogo.svg';
+import FeedList from '../components/FeedList/FeedList';
+import { useEffect, useState } from 'react';
+import { getDetailSubject, getSubjectQuestionList } from '../lib/api/Subject';
+import {
+  SubjectGetDetailParams,
+  SubjectQuestionListParams,
+} from '../core/types/api/Request';
+import {
+  SubjectDetailResponse,
+  SubjectQuestionListResponse,
+} from '../core/types/api/Response';
+import { Link, useParams } from 'react-router-dom';
+import Profile from '../components/Profile/Profile';
+import ModalPage from './ModalPage';
+
 const PostPage = () => {
-  return <div></div>;
+  const { id: subjectId } = useParams();
+  const [subjectInfo, setSubjectInfo] = useState<SubjectDetailResponse>();
+  const [subjectQuestionList, setSubjectQuestionList] =
+    useState<SubjectQuestionListResponse>();
+
+  const fetchDetailSubject = async ({ subjectId }: SubjectGetDetailParams) => {
+    try {
+      const fetchData = await getDetailSubject({ subjectId });
+      setSubjectInfo(fetchData);
+    } catch (error) {}
+  };
+
+  const fetchSubjectQuestionList = async ({
+    subjectId,
+  }: SubjectQuestionListParams) => {
+    try {
+      const fetchData = await getSubjectQuestionList({ subjectId });
+      setSubjectQuestionList(fetchData);
+    } catch (error) {}
+  };
+
+  useEffect(() => {
+    fetchDetailSubject({ subjectId: subjectId as string | number });
+    fetchSubjectQuestionList({ subjectId: subjectId as string | number });
+  }, []);
+
+  return (
+    <>
+      <div className={styles['post-page']}>
+        <Image
+          src={postPageBannerImage}
+          alt="postPageBannerImage"
+          imageClassName={styles['post-page__banner']}
+        />
+        <div className={styles['post-page__profile']}>
+          <Profile
+            profileImage={subjectInfo?.imageSource as string}
+            name={subjectInfo?.name as string}
+          />
+        </div>
+        <Link to="/">
+          <Image
+            src={mainLogo}
+            alt="mainLogo"
+            imageClassName={styles['post-page__logo-img']}
+          />
+        </Link>
+        <div className={styles['post-page__feed-list']}>
+          {subjectQuestionList && (
+            <FeedList
+              count={subjectQuestionList.count}
+              next={subjectQuestionList.next}
+              previous={subjectQuestionList.previous}
+              results={subjectQuestionList.results}
+            />
+          )}
+        </div>
+      </div>
+      <ModalPage
+        name={subjectInfo?.name as string}
+        src={subjectInfo?.imageSource as string}
+        alt={`${subjectInfo?.name}의 프로필 이미지`}
+        subjectId={subjectId as string}
+      />
+    </>
+  );
 };
 
 export default PostPage;


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
개별피드페이지 추가
 /post/{id}

# 작업 상세 내용
- mainLogo이미지 클릭시 메인화면으로 이동기능추가
- profile, feddList, modal 컴포넌트 사용
- modal 버튼 클릭시 모달페이지 생성
- 피드카드의 answer부분은 피드카드컴포넌트 개발 완료후 수정&개발 예정
- ui 스타일 부분은 추후에 수정 할 필요가 있을것같습니다.


# 리뷰 요구사항
피드100주세요!


# 기타

close #85
