### PR TITLE
Feature 111 공통 UButton컴포넌트 buttonTagType prop 추가

### DIFF
--- a/knock/src/core/ui/buttons/UButton/UButton.tsx
+++ b/knock/src/core/ui/buttons/UButton/UButton.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx';
 import styles from './UButton.module.scss';
 
 interface UButtonProps {
+  buttonTagType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
   type: 'box' | 'floating' | 'round';
   className?: string;
   handleClick: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
@@ -12,6 +13,7 @@ interface UButtonProps {
 }
 
 const UButton = ({
+  buttonTagType,
   type,
   className = '',
   handleClick,
@@ -38,6 +40,7 @@ const UButton = ({
         )}
         onClick={handleClick}
         disabled={isDisalbed}
+        type={buttonTagType}
       >
         {children}
       </button>


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요

- 공통 UButton컴포넌트 buttonTagType prop 추가

# 작업 상세 내용

- 공통 UButton컴포넌트 buttonTagType prop 추가
- React.ButtonHTMLAttributes<HTMLButtonElement>['type'] 버튼 엘리먼트의 타입 속성을 사용

# 리뷰 요구사항

- 사용 이슈 없을지 리뷰 부탁드립니다

# 기타

Resolves #111 
