### PR TITLE
Hotfix 카카오 공유버튼으로 인한 post페이지 오류 수정 

### DIFF
--- a/knock/src/core/ui/buttons/ShareButtons/KakaoShareButton/KakaoShareButton.tsx
+++ b/knock/src/core/ui/buttons/ShareButtons/KakaoShareButton/KakaoShareButton.tsx
@@ -24,7 +24,8 @@ interface KaKoShareButtonProps {
 const KakaoShareButton = ({ sharedUrl }: KaKoShareButtonProps) => {
   const { id: userId } = useParams();
   const { users } = useLoscalStorageUserInfo();
-  const userName = users && userId ? users[Number(userId)].name : '';
+  const userName =
+    users && userId && users[Number(userId)] ? users[Number(userId)].name : '';
   const handleKaKaoShare = () => {
     if (window.Kakao === undefined) {
       return;


### PR DESCRIPTION
# 작업분류

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- kakao 공유 버튼 정보 오류에 의한 포스트 페이지 접근 오류 수정

# 작업 상세 내용
- kakao 공유 버튼 정보 중 name을 가져오는 곳의 오류에 의한 포스트 페이지 접근 오류 수정

# 리뷰 요구사항
- 복구 했습니다

# 기타
Closes #159 